### PR TITLE
feat: add Twig syntax highlighting support

### DIFF
--- a/src/vendor/prism/includeLangs.js
+++ b/src/vendor/prism/includeLangs.js
@@ -33,6 +33,7 @@ module.exports = {
   sql: true,
   stylus: true,
   typescript: true,
+  twig: true,
   wasm: true,
   yaml: true
 };


### PR DESCRIPTION
I would love it if we could add support for [Twig](https://twig.symfony.com/) as a templating language! It’s the most popular templating language in the PHP world (with about [2.2 million installs / month](https://packagist.org/packages/twig/twig/stats)) and is used in both Drupal and Symfony. Would really appreciate this getting in! Thanks for the great project that is super helpful!